### PR TITLE
Support all vsync strategies at runtime.

### DIFF
--- a/src/options.h
+++ b/src/options.h
@@ -21,6 +21,12 @@ enum class option_source {
 	CMDLINE
 };
 
+enum vsync_mode_t {
+	VSYNC_MODE_NONE = 0,
+	VSYNC_MODE_GET_SYNC,
+	VSYNC_MODE_WAIT_SYNC,
+};
+
 struct options {
 	char hyper_path[PATH_MAX]  = ".";
 	char rom_path[PATH_MAX]    = "rom.bin";
@@ -52,6 +58,7 @@ struct options {
 	int             warp_factor   = 0;
 	int             window_scale  = 2;
 	scale_quality_t scale_quality = scale_quality_t::NEAREST;
+	vsync_mode_t    vsync_mode    = vsync_mode_t::VSYNC_MODE_GET_SYNC;
 
 	char audio_dev_name[PATH_MAX] = "";
 	bool no_sound                 = false;

--- a/src/overlay/options_menu.cpp
+++ b/src/overlay/options_menu.cpp
@@ -238,6 +238,32 @@ void draw_options_menu()
 		ImGui::SetTooltip("Set scaling quality:\nNearest: Scale by nearest pixel.\nLinear: Scale by linearly averaging between pixels.\nBest: Scale by anisotropic filtering.\nCommand line: -quality {nearest|linear|best}");
 	}
 
+	static auto vsync_name = [](vsync_mode_t vsync_mode) {
+		switch (vsync_mode) {
+			case vsync_mode_t::VSYNC_MODE_NONE: return "None";
+			case vsync_mode_t::VSYNC_MODE_GET_SYNC: return "Get";
+			case vsync_mode_t::VSYNC_MODE_WAIT_SYNC: return "Wait";
+			default: return "Nearest";
+		}
+	};
+
+	if (ImGui::BeginCombo("Vsync Mode", vsync_name(Options.vsync_mode))) {
+		auto selection = [](vsync_mode_t vsync_mode) {
+			if (ImGui::Selectable(vsync_name(vsync_mode), Options.vsync_mode == vsync_mode)) {
+				Options.vsync_mode = vsync_mode;
+			}
+		};
+
+		selection(vsync_mode_t::VSYNC_MODE_NONE);
+		selection(vsync_mode_t::VSYNC_MODE_GET_SYNC);
+		selection(vsync_mode_t::VSYNC_MODE_WAIT_SYNC);
+
+		ImGui::EndCombo();
+	}
+	if (ImGui::IsItemHovered()) {
+		ImGui::SetTooltip("Set vsync mode:\nNone: Do not wait for vsync.\nGet: Check vsync asynchronously.\nWait: Wait for vsync.\nCommand line: -vsync {none|get|wait}");
+	}
+
 	file_option("gif", Options.gif_path, "GIF path", "Location to save gifs\nCommand line: -gif <path>[,wait]");
 	file_option("wav", Options.wav_path, "WAV path", "Location to save wavs\nCommand line: -wav <path>[,wait]");
 	bool_option(Options.load_standard_symbols, "Load Standard Symbols", "Load all symbols files typically included with ROM distributions.\nCommand line: -stds");


### PR DESCRIPTION
Fix for #34 

Enable support for all vsync strategies dynamically during display rendering. Command line and ini file options added to select vsync strategy to use at startup. Vsync strategy options are:

- **none** disable waiting for vsync.
- **get** check asynchronously using `glGetSynciv` to determine if it is time to display the next frame.
- **wait** block using `glClientWait` until it is time to display the next frame.

A menu settings option was also added to change the vsync strategy during runtime. This may need reconsideration. On systems where a driver issue is preventing get/wait from working since switching to them makes all rendered components (including the menu) freeze and become unusable. However on system with no such issues, it might be nice to allow users to change this setting through the menu.