### PR TITLE
fix missing include in ym2151_overlay.cpp for build with Linux g++

### DIFF
--- a/src/overlay/ym2151_overlay.cpp
+++ b/src/overlay/ym2151_overlay.cpp
@@ -5,6 +5,7 @@
 #include "imgui/imgui.h"
 #include "util.h"
 #include "ym2151/ym2151.h"
+#include <cstdio>
 
 static void ym2151_reg_input(uint8_t *regs, uint8_t idx)
 {


### PR DESCRIPTION
This change seems to make this build error go away

```../src/overlay/ym2151_overlay.cpp: In function ‘void draw_debugger_ym2151()’:
../src/overlay/ym2151_overlay.cpp:133:38: error: ‘sprintf’ is not a member of ‘std’; did you mean ‘rintf’?
  133 |                                 std::sprintf(buf, "%d", tim->cur);
      |                                      ^~~~~~~
      |                                      rintf
../src/overlay/ym2151_overlay.cpp: In function ‘void debugger_draw_ym_lfo_and_noise(uint8_t*)’:
../src/overlay/ym2151_overlay.cpp:224:22: error: ‘sprintf’ is not a member of ‘std’; did you mean ‘rintf’?
  224 |                 std::sprintf(buf, "%d", (int)(lcnt * 256));
      |                      ^~~~~~~
      |                      rintf
../src/overlay/ym2151_overlay.cpp: In function ‘void debugger_draw_ym_voice(int, uint8_t*, ym_channel_data&, ym_keyon_state*, std::function<void(unsigned char, unsigned char)>)’:
../src/overlay/ym2151_overlay.cpp:399:22: error: ‘sprintf’ is not a member of ‘std’; did you mean ‘rintf’?
  399 |                 std::sprintf(kcinfo, "%c%c%d %+05.1f", notes[ni], notes[ni + 1], oct, cents);
      |                      ^~~~~~~
      |                      rintf
../src/overlay/ym2151_overlay.cpp:568:38: error: ‘sprintf’ is not a member of ‘std’; did you mean ‘rintf’?
  568 |                                 std::sprintf(buf, "%d", slot.mul);
      |                                      ^~~~~~~
      |                                      rintf
../src/overlay/ym2151_overlay.cpp:650:30: error: ‘sprintf’ is not a member of ‘std’; did you mean ‘rintf’?
  650 |                         std::sprintf(buf2, "%d", (int)((1 - out) * 1024));
      |                              ^~~~~~~
      |                              rintf
make[1]: *** [Makefile:175: obj/box16/obj/overlay/ym2151_overlay.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make[1]: Leaving directory '/home/troy/src/box16/build'
make: *** [Makefile:101: default] Error 2
```