### PR TITLE
Disable patch loading when path is empty

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -690,7 +690,7 @@ static char const *set_options(options &opts, mINI::INIMap<std::string> &ini)
 		opts.rom_path = ini["rom"];
 	}
 
-	if (ini.has("patch")) {
+	if (ini.has("patch") && ini["patch"] != "") {
 		opts.patch_path = ini["patch"];
 		if (!ini.has("ignore_patch") || ini["ignore_patch"] != "true") {
 			opts.apply_patch = true;


### PR DESCRIPTION
In an environment with no pre-existing box16.ini, Box16 will not start unless the `-nopatch` option is passed to it. This happens because by default the `patch` option exists but is an empty string. This PR fixes that by making a non-empty `patch` string a prerequisite to enable the `opts.apply_patch`.