### PR TITLE
Added suppport for new VERA feature AUDIO_CTRL bit6 FIFO_EMPTY info bit.

### DIFF
--- a/src/vera/vera_pcm.cpp
+++ b/src/vera/vera_pcm.cpp
@@ -57,6 +57,9 @@ uint8_t pcm_read_ctrl(void)
 	if (fifo_cnt == sizeof(fifo)) {
 		result |= 0x80;
 	}
+	if (fifo_cnt == 0) {
+		result |= 0x40;
+	}
 	return result;
 }
 


### PR DESCRIPTION
This patch adds support for new VERA feature: AUDIO_CTRL register FIFO_EMPTY flag in bit6 which is set if FIFO is empty.