### PR TITLE
add descriptive reason message when dumping system memory file

### DIFF
--- a/src/glue.h
+++ b/src/glue.h
@@ -32,7 +32,7 @@ extern uint8_t  debug6502;
 
 extern bool save_on_exit;
 
-extern void machine_dump();
+extern void machine_dump(const char* reason);
 extern void machine_reset();
 extern void machine_toggle_warp();
 extern void init_audio();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,8 +63,9 @@ bool save_on_exit = true;
 bool       has_boot_tasks = false;
 SDL_RWops *prg_file       = nullptr;
 
-void machine_dump()
+void machine_dump(const char* reason)
 {
+	printf("Dumping system memory. Reason: %s\n", reason);
 	int  index = 0;
 	char filename[22];
 	for (;;) {
@@ -650,7 +651,7 @@ void emulator_loop()
 
 		if (state6502.pc == 0xffff) {
 			if (save_on_exit) {
-				machine_dump();
+				machine_dump("CPU program counter reached $ffff");
 			}
 			return;
 		}

--- a/src/overlay/overlay.cpp
+++ b/src/overlay/overlay.cpp
@@ -2214,7 +2214,7 @@ static void draw_menu_bar()
 				debugger_interrupt();
 			}
 			if (ImGui::MenuItem("Save Dump", Options.no_keybinds ? nullptr : "Ctrl-S")) {
-				machine_dump();
+				machine_dump("user menu request");
 			}
 			if (ImGui::BeginMenu("Controller Ports")) {
 				joystick_for_each_slot([](int slot, int instance_id, SDL_GameController *controller) {

--- a/src/sdl_events.cpp
+++ b/src/sdl_events.cpp
@@ -81,7 +81,7 @@ bool sdl_events_update()
 					if (cmd_down) {
 						switch (event.key.keysym.sym) {
 							case SDLK_s:
-								machine_dump();
+								machine_dump("user keyboard request");
 								consumed = true;
 								break;
 							case SDLK_r:


### PR DESCRIPTION
box16's version of https://github.com/commanderx16/x16-emulator/pull/460 