### PR TITLE
BRK needs to assert VP

### DIFF
--- a/src/cpu/instructions_6502.h
+++ b/src/cpu/instructions_6502.h
@@ -184,6 +184,7 @@ brk()
 	push8(state6502.status | FLAG_BREAK); // push CPU status to stack
 	setinterrupt();                       // set interrupt flag
 	cleardecimal();                       // clear decimal flag (65C02 change)
+	vp6502();
 	state6502.pc = (uint16_t)read6502(0xFFFE) | ((uint16_t)read6502(0xFFFF) << 8);
 }
 


### PR DESCRIPTION
Mirrors change in https://github.com/X16Community/x16-emulator/pull/114

We broke the BRK instruction, particularly with the MONITOR after merging https://github.com/X16Community/x16-rom/pull/122 without having this change in too.