### PR TITLE
cleanup nicely at poweroff, fixes sticky fullscreen screenmode issue

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -521,6 +521,9 @@ bool display_init(const display_settings &settings)
 
 void display_shutdown()
 {
+	Fullscreen = false;
+	SDL_SetWindowFullscreen(Display_window, 0);
+
 	if (Initd_imgui_opengl)
 		ImGui_ImplOpenGL2_Shutdown();
 

--- a/src/glue.h
+++ b/src/glue.h
@@ -40,7 +40,7 @@ extern void machine_dump(const char *reason);
 extern void machine_reset();
 extern void machine_toggle_warp();
 extern void init_audio();
-
+extern void main_shutdown();
 
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -282,7 +282,9 @@ int main(int argc, char **argv)
 		init_settings.window_rect.h = (480 * Options.window_scale) + IMGUI_OVERLAY_MENU_BAR_HEIGHT;
 		if (const bool initd = display_init(init_settings); initd == false) {
 			printf("Could not initialize display, quitting.\n");
-			goto display_quit;
+			display_shutdown();
+			SDL_Quit();
+			return 0;
 		}
 	}
 
@@ -337,7 +339,13 @@ int main(int argc, char **argv)
 #else
 	emulator_loop();
 #endif
+	SDL_free(const_cast<char *>(private_path));
+	SDL_free(const_cast<char *>(base_path));
+	main_shutdown();
+	return 0;
+}
 
+void main_shutdown() {
 	save_options_on_close(false);
 
 	if (nvram_dirty && !Options.nvram_path.empty()) {
@@ -350,19 +358,12 @@ int main(int argc, char **argv)
 	}
 
 	sdcard_shutdown();
-
-	SDL_free(const_cast<char *>(private_path));
-	SDL_free(const_cast<char *>(base_path));
-
 	audio_close();
 	wav_recorder_shutdown();
 	gif_recorder_shutdown();
 	debugger_shutdown();
-display_quit:
 	display_shutdown();
 	SDL_Quit();
-
-	return 0;
 }
 
 void emulator_loop()

--- a/src/smc.cpp
+++ b/src/smc.cpp
@@ -45,6 +45,7 @@ void smc_write(uint8_t a, uint8_t v)
 		case 1:
 			if (v == 0) {
 				printf("SMC Power Off.\n");
+				main_shutdown();
 				exit(0);
 			} else if (v == 1) {
 				machine_reset();


### PR DESCRIPTION
See https://github.com/X16Community/x16-emulator/pull/115
This is my shot at fixing the same issue here in box16.

may still need some testing on non-linux systems