### PR TITLE
Move the main display inside a window

### DIFF
--- a/src/display.h
+++ b/src/display.h
@@ -17,12 +17,6 @@ struct SDL_FRect {
 };
 #endif
 
-struct display_settings {
-	SDL_Rect window_rect;
-	SDL_Rect video_rect;
-	float    aspect_ratio;
-};
-
 class icon_set
 {
 public:
@@ -49,14 +43,16 @@ private:
 	int      map_height     = 0;
 };
 
-bool  display_init(const display_settings &);
+bool  display_init();
 void  display_shutdown();
 void  display_process();
 float display_get_fps();
 void  display_refund_render_time(uint32_t time_us);
+void  display_video();
 
-const display_settings &display_get_settings();
-SDL_Window             *display_get_window();
+const float    display_get_aspect_ratio();
+SDL_Window *   display_get_window();
+const ImVec4 & display_get_rect();
 
 void display_toggle_fullscreen();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -270,17 +270,8 @@ int main(int argc, char **argv)
 
 	// Initialize display
 	{
-		display_settings init_settings;
-		init_settings.aspect_ratio  = Options.widescreen ? (16.0f / 9.0f) : (4.0f / 3.0f);
-		init_settings.video_rect.x  = 0;
-		init_settings.video_rect.y  = 0;
-		init_settings.video_rect.w  = 640;
-		init_settings.video_rect.h  = 480;
-		init_settings.window_rect.x = 0;
-		init_settings.window_rect.y = 0;
-		init_settings.window_rect.w = (int)(480 * Options.window_scale * init_settings.aspect_ratio);
-		init_settings.window_rect.h = (480 * Options.window_scale) + IMGUI_OVERLAY_MENU_BAR_HEIGHT;
-		if (const bool initd = display_init(init_settings); initd == false) {
+		const bool initd = display_init();
+		if (initd == false) {
 			printf("Could not initialize display, quitting.\n");
 			goto display_quit;
 		}

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -5,6 +5,7 @@
 
 #include "audio.h"
 #include "debugger.h"
+#include "display.h"
 #include "overlay/overlay.h"
 #include "symbols.h"
 #include "version.h"
@@ -1169,6 +1170,7 @@ static void set_panels(mINI::INIMap<std::string> &ini)
 	get_option("vera_psg_monitor", Show_VERA_PSG_monitor);
 	get_option("ym2151_monitor", Show_YM2151_monitor);
 	get_option("midi_overlay", Show_midi_overlay);
+	get_option("display", Show_display);
 }
 
 static void set_ini_main(mINI::INIMap<std::string> &ini_main, bool all)
@@ -1448,6 +1450,14 @@ void set_ini_panels(mINI::INIMap<std::string> &ini, bool all)
 	set_option("midi_overlay", Show_midi_overlay, false);
 }
 
+void set_ini_window(mINI::INIMap<std::string> &ini)
+{
+	int width, height;
+	SDL_GetWindowSize(display_get_window(), &width, &height);
+	ini["width"] = std::to_string(width);
+	ini["height"] = std::to_string(height);
+}
+
 void apply_ini(mINI::INIStructure &dst, const mINI::INIStructure &src)
 {
 	for (const auto &i : src) {
@@ -1521,6 +1531,14 @@ void options_init(const char *base_path, const char *prefs_path, int argc, char 
 	apply_ini(inifile_main);
 	apply_ini(cmdline_main);
 
+	auto & inifile_window = Inifile_ini["window"];
+	if (inifile_window.has("width")) {
+		Options.window_width = std::stoi(inifile_window["width"]);
+	}
+	if (inifile_window.has("height")) {
+		Options.window_height = std::stoi(inifile_window["height"]);
+	}
+
 	if (!cmdline_main.has("nopanels") || cmdline_main["nopanels"] != "true") {
 		set_panels(Inifile_ini["panels"]);
 	}
@@ -1554,6 +1572,7 @@ void save_options(bool all)
 
 	set_ini_main(ini["main"], all);
 	set_ini_panels(ini["panels"], all);
+	set_ini_window(ini["window"]);
 
 	file.generate(ini);
 
@@ -1567,6 +1586,7 @@ void save_options_on_close(bool all)
 	mINI::INIFile file(Options_ini_path.generic_string());
 
 	set_ini_panels(Inifile_ini["panels"], all);
+	set_ini_window(Inifile_ini["window"]);
 
 	file.generate(Inifile_ini);
 }

--- a/src/options.h
+++ b/src/options.h
@@ -105,6 +105,9 @@ struct options {
 	bool ym_strict          = false;
 	bool memory_randomize   = true;
 	bool memory_uninit_warn = false;
+
+	int window_width  = 0;
+	int window_height = 0;
 };
 
 extern options Options;

--- a/src/overlay/overlay.h
+++ b/src/overlay/overlay.h
@@ -21,6 +21,10 @@ extern bool Show_VERA_sprites;
 extern bool Show_VERA_PSG_monitor;
 extern bool Show_YM2151_monitor;
 extern bool Show_midi_overlay;
+extern bool Show_display;
+
+extern bool display_focused;
+extern bool mouse_captured;
 
 void overlay_draw();
 


### PR DESCRIPTION
This PR includes:
- Emulation display is detached into a dockable overlay window. Still needs testing whether GL settings still apply
- Shift+clicking on a display window's title bar will resize it to an integer scale
- Mouse capturing by either clicking or pressing Ctrl-M in a focused display window
- Main app's window size is saved and restored to box16.ini