### PR TITLE
Move VIA1 interrupt to IRQ to match hardware

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -429,7 +429,6 @@ void emulator_loop()
 		cpu_visualization_step();
 		uint8_t clocks       = (uint8_t)(clockticks6502 - old_clockticks6502);
 		bool    new_frame    = vera_video_step(MHZ, clocks);
-		bool    via1_irq_old = via1_irq();
 		via1_step(clocks);
 		via2_step(clocks);
 		rtc_step(clocks);
@@ -458,12 +457,7 @@ void emulator_loop()
 #endif
 		}
 
-		if (!via1_irq_old && via1_irq()) {
-			nmi6502();
-			debugger_interrupt();
-		}
-
-		if (vera_video_get_irq_out() || YM_irq() || via2_irq()) {
+		if (vera_video_get_irq_out() || YM_irq() || via1_irq() || via2_irq()) {
 			irq6502();
 			debugger_interrupt();
 		}


### PR DESCRIPTION
The VIA1 IRQ pin is connected to the system IRQ line as of proto 4.  x16-emulator was changed last year to match.

![image](https://github.com/indigodarkwolf/box16/assets/395186/de6ba7e0-5d2e-47ac-87a6-0b385264c0c4)

https://github.com/X16Community/x16-emulator/commit/be2005b38ac58b8fff7884e38841c42dcd2202be
