### PR TITLE
Update README.md to link to X16Community repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ loaded from the directory containing the emulator binary, or you can use the `-r
 
 > __WARNING:__ Older versions of the ROM might not work in newer versions of the emulator, and vice versa.
 
-You can build a ROM image yourself using the [build instructions](https://github.com/commanderx16/x16-rom#releases-and-building) in the [x16-rom](https://github.com/commanderx16/x16-rom) repo. The `rom.bin` included in the [_latest_ release](https://github.com/commanderx16/x16-emulator/releases) of the emulator may also work with the HEAD of this repo, but this is not guaranteed.
+You can build a ROM image yourself using the [build instructions](https://github.com/X16Community/x16-rom#releases-and-building) in the [x16-rom](https://github.com/X16Community/x16-rom) repo. The `rom.bin` included in the [_latest_ release](https://github.com/X16Community/x16-emulator/releases) of the emulator may also work with the HEAD of this repo, but this is not guaranteed.
 
 ### Linux Build
 
@@ -355,7 +355,7 @@ Forum
 Wiki
 ----
 
-[https://github.com/commanderx16/x16-emulator/wiki](https://github.com/commanderx16/x16-emulator/wiki)
+[https://github.com/commanderx16/x16-emulator/wiki](https://github.com/X16Community/x16-emulator/wiki)
 
 
 License

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build status](https://github.com/indigodarkwolf/box16/actions/workflows/build.yml/badge.svg)](https://github.com/indigodarkwolf/box16/actions/workflows/build.yml)<br/>
 [![Release](https://img.shields.io/github/v/release/indigodarkwolf/box16)](https://github.com/indigodarkwolf/box16/releases)
 
-This is an emulator for the Commander X16 computer system. Unlike [the official emulator](https://github.com/commanderx16/x16-emulator), this has a few more dependencies, see the build instructions below. It compiles on Windows, Debian Linux, and Raspbian, and probably 
+This is an emulator for the Commander X16 computer system. Unlike [the official emulator](https://github.com/X16Community/x16-emulator), this has a few more dependencies, see the build instructions below. It compiles on Windows, Debian Linux, and Raspbian, and probably 
 other Linux-based platforms.
 
 Don't expect official "releases" until the physical X16 is out. Until then, there will be "non-releases" of Box16.


### PR DESCRIPTION
Change link in README to link to X16Community repo of x16emu that is now the primary location for all X16-related software