### PR TITLE
Add the three emulator debug registers to write characters to the console (+ add clock snapshot behavior too)

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -242,10 +242,10 @@ uint8_t debug_emu_read(uint8_t reg)
 		case 5: return gif_recorder_get_state();
 		case 6: return wav_recorder_get_state();
 		case 7: return Options.no_keybinds ? 1 : 0;
-		case 8: return (clockticks6502 >> 0) & 0xff;	// don't do snapshotting here because no state should be changed
-		case 9: return (clockticks6502 >> 8) & 0xff;
-		case 10: return (clockticks6502 >> 16) & 0xff;
-		case 11: return (clockticks6502 >> 24) & 0xff;
+		case 8: return (clock_snap >> 0) & 0xff;	// don't do snapshotting here because no state should be changed
+		case 9: return (clock_snap >> 8) & 0xff;
+		case 10: return (clock_snap >> 16) & 0xff;
+		case 11: return (clock_snap >> 24) & 0xff;
 		// case 12: return -1;
 		case 13: return Options.keymap;
 		case 14: return '1'; // emulator detection

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -36,6 +36,8 @@ uint8_t rom_bank_register;
 static uint64_t *RAM_written;
 
 static uint8_t addr_ym = 0;
+static uint32_t clock_snap = 0UL;
+static uint32_t clock_base = 0UL;
 
 #define DEVICE_EMULATOR (0x9fb0)
 
@@ -240,7 +242,7 @@ uint8_t debug_emu_read(uint8_t reg)
 		case 5: return gif_recorder_get_state();
 		case 6: return wav_recorder_get_state();
 		case 7: return Options.no_keybinds ? 1 : 0;
-		case 8: return (clockticks6502 >> 0) & 0xff;
+		case 8: return (clockticks6502 >> 0) & 0xff;	// don't do snapshotting here because no state should be changed
 		case 9: return (clockticks6502 >> 8) & 0xff;
 		case 10: return (clockticks6502 >> 16) & 0xff;
 		case 11: return (clockticks6502 >> 24) & 0xff;
@@ -263,10 +265,12 @@ uint8_t real_emu_read(uint8_t reg)
 		case 5: return gif_recorder_get_state();
 		case 6: return wav_recorder_get_state();
 		case 7: return Options.no_keybinds ? 1 : 0;
-		case 8: return (clockticks6502 >> 0) & 0xff;
-		case 9: return (clockticks6502 >> 8) & 0xff;
-		case 10: return (clockticks6502 >> 16) & 0xff;
-		case 11: return (clockticks6502 >> 24) & 0xff;
+		case 8: 
+		    clock_snap = clockticks6502 - clock_base;
+		    return (clock_snap >> 0) & 0xff;
+		case 9: return (clock_snap >> 8) & 0xff;
+		case 10: return (clock_snap >> 16) & 0xff;
+		case 11: return (clock_snap >> 24) & 0xff;
 		// case 12: return -1;
 		case 13: return Options.keymap;
 		case 14: return '1'; // emulator detection
@@ -292,7 +296,7 @@ void emu_write(uint8_t reg, uint8_t value)
 		case 5: gif_recorder_set((gif_recorder_command_t)value); break;
 		case 6: wav_recorder_set((wav_recorder_command_t)value); break;
 		case 7: Options.no_keybinds = v; break;
-		// case 8: clock_base = clockticks6502; break;
+		case 8: clock_base = clockticks6502; break;
 		case 9: printf("User debug 1: $%02x\n", value); break;
 		case 10: printf("User debug 2: $%02x\n", value); break;
 		case 11: {

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -291,6 +291,20 @@ void emu_write(uint8_t reg, uint8_t value)
 		case 5: gif_recorder_set((gif_recorder_command_t)value); break;
 		case 6: wav_recorder_set((wav_recorder_command_t)value); break;
 		case 7: Options.no_keybinds = v; break;
+		// case 8: clock_base = clockticks6502; break;
+		case 9: printf("User debug 1: $%02x\n", value); break;
+		case 10: printf("User debug 2: $%02x\n", value); break;
+		case 11: {
+		    if (value == 0x09 || value == 0x0a || value == 0x0d || (value >= 0x20 && value < 0x7f)) {
+			putchar(value);
+		    } else if (value >= 0xa1) {
+			putchar(value);   // print_iso8859_15_char((char) value);
+		    } else {
+			printf("\xef\xbf\xbd"); // �
+		    }
+		    fflush(stdout);
+		    break;
+		}
 		default: break; // printf("WARN: Invalid register %x\n", DEVICE_EMULATOR + reg);
 	}
 }

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -16,6 +16,7 @@
 #include "gif_recorder.h"
 #include "glue.h"
 #include "hypercalls.h"
+#include "unicode.h"
 #include "vera/vera_video.h"
 #include "via.h"
 #include "wav_recorder.h"
@@ -298,7 +299,7 @@ void emu_write(uint8_t reg, uint8_t value)
 		    if (value == 0x09 || value == 0x0a || value == 0x0d || (value >= 0x20 && value < 0x7f)) {
 			putchar(value);
 		    } else if (value >= 0xa1) {
-			putchar(value);   // print_iso8859_15_char((char) value);
+			print_iso8859_15_char((char) value);
 		    } else {
 			printf("\xef\xbf\xbd"); // �
 		    }

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -36,8 +36,8 @@ uint8_t rom_bank_register;
 static uint64_t *RAM_written;
 
 static uint8_t addr_ym = 0;
-static uint32_t clock_snap = 0UL;
-static uint32_t clock_base = 0UL;
+static uint64_t clock_snap = 0UL;
+static uint64_t clock_base = 0UL;
 
 #define DEVICE_EMULATOR (0x9fb0)
 


### PR DESCRIPTION
Mimics recent additions to x16emu.

2 notes:
- I don't know how to translate the behavior of writing to register 8 to box16
- I don't know why x16emu goes through the trouble of converting a character before actually printing it? (print_iso8859_15_char)   Just putchar'ing it to the console works fine?