### PR TITLE
Port MCIOUT hypercall from x16-emulator, fix MACPTR bug

### DIFF
--- a/src/ieee.h
+++ b/src/ieee.h
@@ -16,5 +16,6 @@ int  UNLSN();
 void LISTEN(uint8_t a);
 void TALK(uint8_t a);
 int  MACPTR(uint16_t addr, uint16_t *count, uint8_t stream_mode);
+int  MCIOUT(uint16_t addr, uint16_t *count, uint8_t stream_mode);
 
 #endif


### PR DESCRIPTION
This adds MCIOUT, new API call for blockwise/stream write in ROM, which is also supported on x16-emulator hostfs.

Unfortunately the low byte of the PC of this new call clashes with LISTEN, so the hypercall table needed another bit.

Also, MACPTR would always return only one byte regardless of how many bytes were requested due to a mismatch between what the MACPTR was expecting as a return value from ACPTR, and what ACPTR was actually returning.  I changed both MACPTR and CIOUT to match x16-emulator's implementation.