### PR TITLE
Port corrected PCM underflow behavior from x16-emulator

### DIFF
--- a/src/vera/vera_pcm.cpp
+++ b/src/vera/vera_pcm.cpp
@@ -114,29 +114,49 @@ void pcm_render(int16_t *buf, unsigned num_samples)
 		uint8_t old_phase = phase;
 		phase += rate;
 		if ((old_phase & 0x80) != (phase & 0x80)) {
-			switch ((ctrl >> 4) & 3) {
-				case 0: { // mono 8-bit
-					cur_l = (int16_t)read_fifo() << 8;
-					cur_r = cur_l;
-					break;
-				}
-				case 1: { // stereo 8-bit
-					cur_l = read_fifo() << 8;
-					cur_r = read_fifo() << 8;
-					break;
-				}
-				case 2: { // mono 16-bit
-					cur_l = read_fifo();
-					cur_l |= read_fifo() << 8;
-					cur_r = cur_l;
-					break;
-				}
-				case 3: { // stereo 16-bit
-					cur_l = read_fifo();
-					cur_l |= read_fifo() << 8;
-					cur_r = read_fifo();
-					cur_r |= read_fifo() << 8;
-					break;
+			if (fifo_cnt == 0) {
+				cur_l = 0;
+				cur_r = 0;
+			} else {
+				switch ((ctrl >> 4) & 3) {
+					case 0: { // mono 8-bit
+						cur_l = (int16_t)read_fifo() << 8;
+						cur_r = cur_l;
+						break;
+					}
+					case 1: { // stereo 8-bit
+						if (fifo_cnt < 2) {
+							fifo_cnt = 0;
+							fifo_rdidx = fifo_wridx;
+						} else {
+							cur_l = read_fifo() << 8;
+							cur_r = read_fifo() << 8;
+						}
+						break;
+					}
+					case 2: { // mono 16-bit
+						if (fifo_cnt < 2) {
+							fifo_cnt = 0;
+							fifo_rdidx = fifo_wridx;
+						} else {
+							cur_l = read_fifo();
+							cur_l |= read_fifo() << 8;
+							cur_r = cur_l;
+						}
+						break;
+					}
+					case 3: { // stereo 16-bit
+						if (fifo_cnt < 4) {
+							fifo_cnt = 0;
+							fifo_rdidx = fifo_wridx;
+						} else {
+							cur_l = read_fifo();
+							cur_l |= read_fifo() << 8;
+							cur_r = read_fifo();
+							cur_r |= read_fifo() << 8;
+						}
+						break;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This was changed to match hardware.