### PR TITLE
Handle R47 relocation of kernal signature

### DIFF
--- a/src/hypercalls.cpp
+++ b/src/hypercalls.cpp
@@ -42,10 +42,15 @@ static bool is_kernal()
 {
 	const uint8_t rom_bank = memory_get_rom_bank();
 
-	return debug_read6502(0xfff6, rom_bank) == 'M' && // only for KERNAL
-	       debug_read6502(0xfff7, rom_bank) == 'I' &&
-	       debug_read6502(0xfff8, rom_bank) == 'S' &&
-	       debug_read6502(0xfff9, rom_bank) == 'T';
+	// only for KERNAL
+	return (debug_read6502(0xfff6, rom_bank) == 'M' &&
+	        debug_read6502(0xfff7, rom_bank) == 'I' &&
+	        debug_read6502(0xfff8, rom_bank) == 'S' &&
+	        debug_read6502(0xfff9, rom_bank) == 'T')
+	    || (debug_read6502(0xc008, rom_bank) == 'M' &&
+	        debug_read6502(0xc009, rom_bank) == 'I' &&
+	        debug_read6502(0xc00a, rom_bank) == 'S' &&
+	        debug_read6502(0xc00b, rom_bank) == 'T');
 }
 
 static bool init_kernal_status()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -151,10 +151,15 @@ void machine_toggle_warp()
 
 static bool is_kernal()
 {
-	return read6502(0xfff6) == 'M' && // only for KERNAL
-	       read6502(0xfff7) == 'I' &&
-	       read6502(0xfff8) == 'S' &&
-	       read6502(0xfff9) == 'T';
+	// only for KERNAL
+	return (read6502(0xfff6) == 'M' &&
+	        read6502(0xfff7) == 'I' &&
+	        read6502(0xfff8) == 'S' &&
+	        read6502(0xfff9) == 'T')
+	    || (read6502(0xc008) == 'M' &&
+	        read6502(0xc009) == 'I' &&
+	        read6502(0xc00a) == 'S' &&
+	        read6502(0xc00b) == 'T');
 }
 
 #undef main


### PR DESCRIPTION
In order to remove the conflict for the emulated COP vector for the ROM's 65C816 support, the `MIST` signature was moved from $fff6 to $c008.  x16-emulator has been updated to support both for now.