### PR TITLE
Add check for return value of hypercall MACPTR()

### DIFF
--- a/src/hypercalls.cpp
+++ b/src/hypercalls.cpp
@@ -183,7 +183,12 @@ void hypercalls_update()
 
 			state6502.x = count & 0xff;
 			state6502.y = count >> 8;
-			state6502.status &= 0xfe; // clear C -> supported
+			
+			if (s == -3) {
+				state6502.status |= 0x01; // set C -> unsupported
+			} else {
+				state6502.status &= 0xfe; // clear C -> supported
+			}
 
 			set_kernal_status(s);
 			return true;


### PR DESCRIPTION
This PR fixes the issue where LOAD'ing files from HostFS using SA 2 or 3 would cause the KERNAL to never return control to the user if the file wasn't actually present. ( Closes #111 )

It adds a check for the return value of the MACPTR() hypercall so that if MACPTR() returns `-3` to represent it is unsupported, it sets the carry flag as appropriate.
![image](https://github.com/indigodarkwolf/box16/assets/72891927/6b3bc458-a27b-4830-90d3-ac59762bdfe5)
