### PR TITLE
Fixed incorrect display of registers in CPU Monitor

### DIFF
--- a/src/overlay/util.h
+++ b/src/overlay/util.h
@@ -49,8 +49,8 @@ namespace ImGui
 		constexpr const size_t ARRAY_SIZE = BITS / 4 + 1;
 		char                   data[ARRAY_SIZE];
 
-		fmt::format_to_n(data, ARRAY_SIZE - 1, "{:0{}x}", value, ARRAY_SIZE - 1);
-		data[0] = '\0';
+		fmt::format_to_n(data, ARRAY_SIZE - 1, "{:0{}X}", value, ARRAY_SIZE - 1);
+		data[ARRAY_SIZE - 1] = '\0';
 
 		TextUnformatted(name.c_str());
 		SameLine();


### PR DESCRIPTION
At some point the display of the CPU registers went blank.
![image](https://github.com/user-attachments/assets/42282e3d-e0a5-4578-94a9-4204ac8b71a4)

I haven't been following the progress but I'm guessing it was changed incorrectly.

This pull request fixes that, by setting the terminating char '\0' at the right index and also makes the hexidecimal display uppercase.