### PR TITLE
Improve audio mixing balance, add simple limiter similar to x16emu

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -71,7 +71,7 @@ YMFM_OBJDIR := $(OBJDIR)/ymfm
 
 YMFM_CXXFLAGS := $(CXXFLAGS) $(CXXWARNS)
 
-YMFM_SRCS := $(YMFM_SRCDIR)/ymfm_opm.cpp	
+YMFM_SRCS := $(YMFM_SRCDIR)/ymfm_opm.cpp
 YMFM_OBJS := $(patsubst $(YMFM_SRCDIR)/%.cpp,$(YMFM_OBJDIR)/%.o,$(YMFM_SRCS))
 
 #

--- a/build/Makefile
+++ b/build/Makefile
@@ -71,7 +71,7 @@ YMFM_OBJDIR := $(OBJDIR)/ymfm
 
 YMFM_CXXFLAGS := $(CXXFLAGS) $(CXXWARNS)
 
-YMFM_SRCS := $(YMFM_SRCDIR)/ymfm_opm.cpp
+YMFM_SRCS := $(YMFM_SRCDIR)/ymfm_opm.cpp	
 YMFM_OBJS := $(patsubst $(YMFM_SRCDIR)/%.cpp,$(YMFM_OBJDIR)/%.o,$(YMFM_SRCS))
 
 #
@@ -90,7 +90,7 @@ BOX16_LDFLAGS := $(DFLAGS) $(MYFLAGS) $(shell $(PKGCONFIG) --libs alsa gl zlib) 
 
 # Detect if CXX is g++ or clang++, in this order.
 ifeq '' '$(findstring clang++,$(CXX))'
-  BOX16_LDFLAGS += -lstdc++fs
+	BOX16_LDFLAGS += -lstdc++fs
 endif
 
 #=========================


### PR DESCRIPTION
The existing mixer has always made the VERA too quiet.  It seemed to lay down the output of FM first into the buffer, then mix in the other two sources independently.  There wasn't much ability to adjust the relative balance between the chip sources with this.

Replaced with a loop that mixes the audio sources' samples individually, with a limiter.   The VERA and YM balance is much closer to hardware now.