### PR TITLE
Fix non-power-of-two scaling sometimes causing sprites to have off-by-one width

### DIFF
--- a/src/vera/vera_video.cpp
+++ b/src/vera/vera_video.cpp
@@ -526,7 +526,7 @@ static void render_sprite_line(const uint16_t y)
 
 		const int32_t scale          = reg_composer[1];
 		const int16_t scaled_x_start = scale ? ((int32_t)props->sprite_x << 7) / scale : (props->sprite_x ? SCREEN_WIDTH : 0);
-		const int16_t scaled_x_end   = scale ? scaled_x_start + (((int32_t)width << 7) / scale) : SCREEN_WIDTH;
+		const int16_t scaled_x_end   = scale ? (((int32_t)(props->sprite_x + width) << 7) / scale) : SCREEN_WIDTH;
 		const bool    hflip          = props->hflip;
 		for (int16_t sx = scaled_x_start; sx < scaled_x_end; sx += 1) {
 			if ((uint16_t)sx >= SCREEN_WIDTH) {


### PR DESCRIPTION
Copying the meat of the explanation from https://discord.com/channels/862752657743675432/862752657743675435/1338247164593176607

---
For instance there are three columns of sprites that make up the character here when it's at this specific position:

X = 149, 157, 165.

But we'll look at only the first two since those are the ones at issue that have a gap.

Horizontal Scaling is set to 51 decimal ($33), which gives an effective screen width of 255 pixels.

The scaling code here will calculate these scaled_x_start and scaled_x_end values thusly.

For sprite_x = 149:

```c
scaled_x_start = (149 << 7) / 51 = 373 // 373.960784314
scaled_x_end = 373 + ((8 << 7) / 51) = 393
```

For sprite_x = 157:

```c
scaled_x_start = (157 << 7) / 51 = 394 // 394.039215686
scaled_x_end = 394 + ((8 << 7) / 51) = 414
```

As you can see between these two calculations, there is a 1 pixel gap in between these sprites.
