### PR TITLE
VERA PSG: fix noise freq double that of hardware

### DIFF
--- a/src/vera/vera_psg.cpp
+++ b/src/vera/vera_psg.cpp
@@ -65,7 +65,7 @@ static void render(int16_t *left, int16_t *right)
 		struct psg_channel *ch = &Channels[i];
 
 		uint32_t new_phase = (ch->left || ch->right) ? ((ch->phase + ch->freq) & 0x1FFFF) : 0;
-		if ((ch->phase & 0x10000) != (new_phase & 0x10000)) {
+		if ((ch->phase & 0x10000) && !(new_phase & 0x10000)) {
 			ch->noiseval = (noise_state >> 1) & 0x3F;
 		}
 		ch->phase = new_phase;


### PR DESCRIPTION
Port https://github.com/X16Community/x16-emulator/pull/342 to Box16.  See https://github.com/X16Community/x16-emulator/issues/341 for original bug report.