### PR TITLE
Print warnings when reading write-only VERA register, or writing read-only

### DIFF
--- a/src/vera/vera_video.cpp
+++ b/src/vera/vera_video.cpp
@@ -10,6 +10,7 @@
 #include "vera_psg.h"
 #include "vera_spi.h"
 #include "files.h"
+#include "glue.h"
 
 #include <algorithm>
 #include <limits.h>
@@ -1308,6 +1309,85 @@ void vera_video_space_write(uint32_t address, uint8_t value)
 //
 // if debugOn, read without any side effects (registers & memory unchanged)
 
+static void check_not_readonly(uint8_t reg) {
+	bool wrong = false;
+	switch(io_dcsel) {
+		case 5: {
+			switch(reg) {
+				case 0x0b:		// DCSEL=5 FX_POLY_FILL_L
+				case 0x0c:		// DCSEL=5 FX_POLY_FILL_H
+					wrong=true;
+					break;
+			}
+			break;
+		}
+		case 63: {
+			switch(reg) {
+				case 0x09:		// DCSEL=63 DC_VER0
+				case 0x0a:		// DCSEL=63 DC_VER1
+				case 0x0b:		// DCSEL=63 DC_VER2
+				case 0x0c:		// DCSEL=63 DC_VER3
+					wrong=true;
+					break;
+			}
+			break;
+		}
+	}
+
+	if(wrong)
+		fmt::print("Warning: {:04X} wrote to read-only VERA register at 9F{:02X} (DCSEL={})\n", debug_state6502.pc, reg+0x20, io_dcsel);
+}
+
+static void check_not_writeonly(uint8_t reg) {
+	bool wrong = false;
+	switch(io_dcsel) {
+		case 2: {
+			switch(reg) {
+				case 0x0a:		// DCSEL=2 FX_TILEBASE
+				case 0x0b:		// DCSEL=2 FX_MAPBASE
+				case 0x0c:		// DCSEL=2 FX_MULT
+					wrong=true;
+					break;
+			}
+			break;
+		}
+		case 3:
+		case 4: {
+			switch(reg) {
+				case 0x09:		// DCSEL=3/4 FX_X_INCR_L/FX_X_POS_L
+				case 0x0a:		// DCSEL=3/4 FX_X_INCR_H/FX_X_POS_H
+				case 0x0b:		// DCSEL=3/4 FX_Y_INCR_L/FX_Y_POS_L
+				case 0x0c:		// DCSEL=3/4 FX_Y_INCR_H/FX_Y_POS_H
+					wrong=true;
+					break;
+			}
+			break;
+		}
+		case 5: {
+			switch(reg) {
+				case 0x09:		// DCSEL=5 FX_X_POS_S
+				case 0x0a:		// DCSEL=5 FX_Y_POS_S
+					wrong=true;
+					break;
+			}
+			break;
+		}
+		case 6: {
+			switch(reg) {
+				case 0x0b:		// DCSEL=6 FX_CACHE_H
+				case 0x0c:		// DCSEL=6 FX_CACHE_U
+					wrong=true;
+					break;
+			}
+			break;
+		}
+	}
+
+	if(wrong)
+		fmt::print("Warning: {:04X} read from write-only VERA register at 9F{:02X} (DCSEL={})\n", debug_state6502.pc, reg+0x20, io_dcsel);
+}
+
+
 uint8_t vera_debug_video_read(uint8_t reg)
 {
 	const bool     ntsc_mode = reg_composer[0] & 2;
@@ -1412,6 +1492,8 @@ uint8_t vera_video_read(uint8_t reg)
 	const bool     ntsc_mode = reg_composer[0] & 2;
 	const uint16_t scanline  = std::min(511, ntsc_mode ? ntsc_scan_pos_y % SCAN_HEIGHT : vga_scan_pos_y);
 
+	check_not_writeonly(reg);
+	
 	switch (reg & 0x1F) {
 		case 0x00: return io_addr[io_addrsel] & 0xff;
 		case 0x01: return (io_addr[io_addrsel] >> 8) & 0xff;
@@ -1560,6 +1642,9 @@ void vera_video_write(uint8_t reg, uint8_t value)
 	// 	fmt::print("ioregisters[{:#02X}] = {:#02X}\n", reg, value);
 	// }
 	//	fmt::print("ioregisters[{:d}] = ${:02X}\n", reg, value);
+    
+    	check_not_readonly(reg);
+	
 	switch (reg & 0x1F) {
 		case 0x00:
 			if (fx_2bit_poly && fx_4bit_mode && fx_addr1_mode == 2 && io_addrsel == 1) {


### PR DESCRIPTION
Box16's equivalent of https://github.com/X16Community/x16-emulator/pull/359

Implemented after Wavicle's sleuthing for the cause of the Another World graphics glitch
see forum post https://cx16forum.com/forum/viewtopic.php?p=37485#p37485

example output

Warning: 086E read from write-only VERA register at 9F2B (DCSEL=6)
Warning: 0875 read from write-only VERA register at 9F2C (DCSEL=6)


*question* @indigodarkwolf  I don't understand the difference between the "debug" versions of several routines and structures vs. the regular ones. Did I modify the right ones? When should you use the "debug" versions? 
(example: `debug_state6502.pc` vs `state6502.pc`  and `vera_debug_video_read()` vs `vera_video_read()`)